### PR TITLE
Bugfix past leaderboard and player evolution gaussian ratings

### DIFF
--- a/pandaskill/app/leaderboard_page.py
+++ b/pandaskill/app/leaderboard_page.py
@@ -78,9 +78,9 @@ def _get_leaderboard_parameters(data):
         role = st.selectbox("Role", all_roles_choice, 0)
 
     since = date - dt.timedelta(days=30*6)
-    since = since.strftime("%Y-%m-%d")
     parameters = {
-        "since": since,
+        "since": since.strftime("%Y-%m-%d"),
+        "date": date.strftime("%Y-%m-%d"),
         "min_nb_games": min_nb_games
     }
     data = data.loc[data["date"] <= dt.datetime.combine(date, dt.datetime.min.time())]

--- a/pandaskill/app/misc.py
+++ b/pandaskill/app/misc.py
@@ -9,3 +9,9 @@ def compute_rating_lower_bound(rating_mu, rating_sigma):
     In that sense, it's a conservative estimate of the player's rating. See the paper for more information.
     """
     return rating_mu - 3 * rating_sigma
+
+def compute_rating_upper_bound(rating_mu, rating_sigma):
+    """ 
+    Similar to compute_rating_lower_bound, but it represents a 99.7% confidence that the rating of the player is lower that this value.
+    """
+    return rating_mu + 3 * rating_sigma

--- a/pandaskill/app/player_team_page.py
+++ b/pandaskill/app/player_team_page.py
@@ -3,7 +3,7 @@ import datetime as dt
 import pandas as pd
 import altair as alt
 import numpy as np
-from pandaskill.app.misc import compute_rating_lower_bound
+from pandaskill.app.misc import compute_rating_lower_bound, compute_rating_upper_bound
 
 def display_player_team_page(data):
     """
@@ -117,6 +117,7 @@ def _select_date_range(skill_ratings):
 
 def _display_player_evolution(skill_ratings):
     skill_ratings["skill_rating_997%"] = compute_rating_lower_bound(skill_ratings["skill_rating_mu"], skill_ratings["skill_rating_sigma"])
+    skill_ratings["skill_rating_003%"] = compute_rating_upper_bound(skill_ratings["skill_rating_mu"], skill_ratings["skill_rating_sigma"])
     secondary_y_axis = "pscore"
 
     skill_ratings["pscore_mean"] = skill_ratings.groupby("series_name")["pscore"].transform("mean")
@@ -146,11 +147,11 @@ def _display_player_evolution(skill_ratings):
     if show_gaussian_ratings:
         rating_chart_area = base.mark_area().encode(
             x=alt.X('index:Q', axis=alt.Axis(title='Game number'), ),
-            y=alt.Y(f"skill_rating:Q", axis=alt.Axis(title='Skill Rating'), scale=alt.Scale(
-                domainMin=float(skill_ratings["skill_rating"].min()) -1,
-                domainMax=float(skill_ratings["skill_rating_997%"].max() + 1)
+            y=alt.Y(f"skill_rating_997%:Q", axis=alt.Axis(title='Skill Rating'), scale=alt.Scale(
+                domainMin=float(skill_ratings["skill_rating_997%"].min()) -1,
+                domainMax=float(skill_ratings["skill_rating_003%"].max() + 1)
             )),
-            y2=alt.Y2(f"skill_rating_997%:Q"),
+            y2=alt.Y2(f"skill_rating_003%:Q"),
             color="entity_name:N",
             opacity=alt.value(0.4),
         ).properties(

--- a/pandaskill/experiments/run_skill_rating_experiment.py
+++ b/pandaskill/experiments/run_skill_rating_experiment.py
@@ -90,7 +90,8 @@ if __name__ == "__main__":
         },
         "ranking":{
             "min_nb_games": 10,
-            "since": "2024-03-15"
+            "since": "2024-03-15",
+            "date": "2024-09-15"
         }
     }
     logging.info(f"Starting skill rating experiment `{config['experiment']}`")

--- a/pandaskill/experiments/skill_rating/ranking.py
+++ b/pandaskill/experiments/skill_rating/ranking.py
@@ -36,7 +36,9 @@ def create_global_player_ranking(
     data_with_ratings: pd.DataFrame, 
     parameters: dict
 ) -> pd.DataFrame:
-    data_with_ratings = data_with_ratings[data_with_ratings.date > parameters["since"]]
+    data_with_ratings = data_with_ratings[
+        (data_with_ratings.date <= parameters["date"]) & (data_with_ratings.date > parameters["since"])
+    ]
 
     most_played_recent_league_by_player = data_with_ratings.groupby("player_id")["league_name"].agg(
         lambda x: x.mode()[0]


### PR DESCRIPTION
- Leaderboard page correctly displays ranking when the date is not the last available date (past rankings)
- Gaussian ratings are now correctly displayed as colored intervals in the player evolution page